### PR TITLE
Basic XP adjustment added

### DIFF
--- a/src/webui/src/pages/Index.vue
+++ b/src/webui/src/pages/Index.vue
@@ -213,6 +213,11 @@
         <div class="column">
           <q-banner dense class="text-white" style="background: #581911">
             Total Encounter cost: {{ xpCost }}
+            <div class="xp-award" v-if="partySize > 0 && partySize != 4">
+              <small>
+                XP Award: {{ Math.floor((xpCost * 4) / partySize) }}
+              </small>
+            </div>
           </q-banner>
           <q-virtual-scroll
             data-v-step="3"


### PR DESCRIPTION
Added an additional line below the Total Encounter Cost when the party size is set to greater than 0 and not 4. This calculates the XP that should be awarded to players based on the formula: (Encounter XP * 4) / Party Size.

This provides the user with the correct amount of experience that should be awarded to each player adjusted for party sizes other than the standard 4.